### PR TITLE
Coords opts

### DIFF
--- a/lightning/types/images.py
+++ b/lightning/types/images.py
@@ -2,7 +2,7 @@ from numpy import ndarray, asarray
 
 from lightning.types.base import Base
 from lightning.types.decorators import viztype
-from lightning.types.utils import array_to_im, mask_to_points, polygon_to_mask
+from lightning.types.utils import array_to_im, polygon_to_points, polygon_to_mask
 
 
 @viztype
@@ -32,8 +32,14 @@ class Image(Base):
         """
         Get data from polygons drawn on image.
 
-        :param return_type:
-        :return:
+        Parameters
+        ----------
+        return_type : string, optional, default='bounds'
+            Specification of output data. Options are 'bounds','points', and 'mask'
+
+        dims : array-like, optional, default=None
+            Specify the size of the image containing the polygon.
+
         """
 
         user_data = self.get_user_data()['settings']
@@ -43,15 +49,13 @@ class Image(Base):
             if return_type == 'bounds':
                 return coords
 
+            elif return_type == 'points':
+                return [polygon_to_points(x) for x in coords]
+
             elif return_type == 'mask':
                 if not dims:
                     raise Exception('Must provide image dimensions to return mask')
                 return [polygon_to_mask(x, dims) for x in coords]
-
-            elif return_type == 'points':
-                if not dims:
-                    raise Exception('Must provide image dimensions to return inner points')
-                return [mask_to_points(polygon_to_mask(x, dims)) for x in coords]
 
             else:
                 raise Exception('Option %s is not supported' % return_type)

--- a/lightning/types/images.py
+++ b/lightning/types/images.py
@@ -2,7 +2,7 @@ from numpy import ndarray, asarray
 
 from lightning.types.base import Base
 from lightning.types.decorators import viztype
-from lightning.types.utils import array_to_im, get_points_from_polygon
+from lightning.types.utils import array_to_im, mask_to_points, polygon_to_mask
 
 
 @viztype
@@ -28,14 +28,33 @@ class Image(Base):
 
         return {'images': outdict}
     
-    def get_coords(self, as_points=False):
+    def get_coords(self, return_type='bounds', dims=None):
+        """
+        Get data from polygons drawn on image.
+
+        :param return_type:
+        :return:
+        """
+
         user_data = self.get_user_data()['settings']
-        if 'coords' in user_data.keys():            
+        if 'coords' in user_data.keys():
             coords = user_data['coords']
-            if as_points:
-                return [get_points_from_polygon(x) for x in coords]
+
+            if return_type == 'bounds':
+                return coords
+
+            elif return_type == 'mask':
+                if not dims:
+                    raise Exception('Must provide image dimensions to return mask')
+                return [polygon_to_mask(x, dims) for x in coords]
+
+            elif return_type == 'points':
+                if not dims:
+                    raise Exception('Must provide image dimensions to return inner points')
+                return [mask_to_points(polygon_to_mask(x, dims)) for x in coords]
+
             else:
-                return coords        
+                raise Exception('Option %s is not supported' % return_type)
         else:
             return []
 

--- a/lightning/types/images.py
+++ b/lightning/types/images.py
@@ -27,9 +27,8 @@ class Image(Base):
         outdict = [array_to_im(imagedata)]
 
         return {'images': outdict}
-
-    @property
-    def coords(self, as_points=False):
+    
+    def get_coords(self, as_points=False):
         user_data = self.get_user_data()['settings']
         if 'coords' in user_data.keys():            
             coords = user_data['coords']

--- a/lightning/types/images.py
+++ b/lightning/types/images.py
@@ -2,7 +2,7 @@ from numpy import ndarray, asarray
 
 from lightning.types.base import Base
 from lightning.types.decorators import viztype
-from lightning.types.utils import array_to_im
+from lightning.types.utils import array_to_im, get_points_from_polygon
 
 
 @viztype
@@ -29,10 +29,14 @@ class Image(Base):
         return {'images': outdict}
 
     @property
-    def coords(self):
+    def coords(self, as_points=False):
         user_data = self.get_user_data()['settings']
-        if 'coords' in user_data.keys():
-            return user_data['coords']
+        if 'coords' in user_data.keys():            
+            coords = user_data['coords']
+            if as_points:
+                return [get_points_from_polygon(x) for x in coords]
+            else:
+                return coords        
         else:
             return []
 

--- a/lightning/types/utils.py
+++ b/lightning/types/utils.py
@@ -208,25 +208,33 @@ def list_to_regions(reg):
             raise Exception("All region names must be two letters (for US) or three letters (for world)")
         return reg
 
-def get_points_from_polygon(coords):
+
+def polygon_to_mask(coords, dims):
+
     """
-    Given a list of pairs of points which define a polygon, return a list of points interior to the polygon
+    Given a list of pairs of points which define a polygon, return a binary
+    mask covering the interior of the polygon
     """
-    
+
     bounds = array(coords).astype('int')
-
-    bMax = bounds.max(0)
-    bMin = bounds.min(0)
-
     path = Path(bounds)
 
-    grid = meshgrid(range(bMin[0],bMax[0]+1),range(bMin[1],bMax[1]+1))
+    grid = meshgrid(range(dims[1]), range(dims[0]))
+    grid_flat = zip(grid[0].ravel(), grid[1].ravel())
 
-    gridFlat = zip(grid[0].ravel(),grid[1].ravel())
+    mask = path.contains_points(grid_flat).reshape(dims[0:2]).astype('int')
 
-    inside = path.contains_points(gridFlat).reshape(grid[0].shape).astype('int')
-    inside = where(inside)
-    inside = vstack([inside[0],inside[1]]).T + bMin[-1::-1]    
-    inside.tolist()
-    
-    return inside
+    return mask
+
+
+def mask_to_points(mask):
+
+    """
+    Convert binary mask to a list of (y,x) points for each point where the mask is 1
+    """
+
+    points = where(mask)
+    points = vstack([points[0], points[1]]).T
+    points = points.tolist()
+
+    return points

--- a/lightning/types/utils.py
+++ b/lightning/types/utils.py
@@ -1,5 +1,5 @@
-from numpy import asarray, array, ndarray, vstack, newaxis, nonzero, concatenate, transpose, atleast_2d, size, isscalar
-
+from numpy import asarray, array, ndarray, vstack, newaxis, nonzero, concatenate, transpose, atleast_2d, size, isscalar, meshgrid, where
+from matplotlib.path import Path
 
 def add_property(d, prop, name):
 
@@ -207,3 +207,26 @@ def list_to_regions(reg):
         if not (checktwo or checkthree):
             raise Exception("All region names must be two letters (for US) or three letters (for world)")
         return reg
+
+def get_points_from_polygon(coords):
+    """
+    Given a list of pairs of points which define a polygon, return a list of points interior to the polygon
+    """
+    
+    bounds = array(coords).astype('int')
+
+    bMax = bounds.max(0)
+    bMin = bounds.min(0)
+
+    path = Path(bounds)
+
+    grid = meshgrid(range(bMin[0],bMax[0]+1),range(bMin[1],bMax[1]+1))
+
+    gridFlat = zip(grid[0].ravel(),grid[1].ravel())
+
+    inside = path.contains_points(gridFlat).reshape(grid[0].shape).astype('int')
+    inside = where(inside)
+    inside = vstack([inside[0],inside[1]]).T + bMin[-1::-1]    
+    inside.tolist()
+    
+    return inside

--- a/lightning/types/utils.py
+++ b/lightning/types/utils.py
@@ -210,7 +210,6 @@ def list_to_regions(reg):
 
 
 def polygon_to_mask(coords, dims):
-
     """
     Given a list of pairs of points which define a polygon, return a binary
     mask covering the interior of the polygon
@@ -227,14 +226,26 @@ def polygon_to_mask(coords, dims):
     return mask
 
 
-def mask_to_points(mask):
-
+def polygon_to_points(coords):
     """
-    Convert binary mask to a list of (y,x) points for each point where the mask is 1
+    Given a list of pairs of points which define a polygon,
+    return a list of points interior to the polygon
     """
 
-    points = where(mask)
-    points = vstack([points[0], points[1]]).T
+    bounds = array(coords).astype('int')
+
+    bmax = bounds.max(0)
+    bmin = bounds.min(0)
+
+    path = Path(bounds)
+
+    grid = meshgrid(range(bmin[0], bmax[0]+1), range(bmin[1], bmax[1]+1))
+
+    grid_flat = zip(grid[0].ravel(), grid[1].ravel())
+
+    points = path.contains_points(grid_flat).reshape(grid[0].shape).astype('int')
+    points = where(points)
+    points = vstack([points[0], points[1]]).T + bmin[-1::-1]
     points = points.tolist()
 
     return points


### PR DESCRIPTION
This addition adds the ability to get the set of (x,y) points inside a polygon drawn in an instance of `lightning.image` 

To test this new functionality, draw a region on an image and call the following:

```
# get set of pixels from image
coords = viz.get_coords(as_points=True)[0]
# build an array with the same size in (x,y) as the image data
tmp = np.zeros(dims[0:2])

# for each pixel, color the image at that point.
for pix in coords:
        tmp[pix[0],pix[1]] = 1

# the resulting binary image should match the shape and position of the drawn polygon
plt.imshow(tmp)

```