### PR TITLE
Cast ranges to lists for force and adjacency plots 

### DIFF
--- a/lightning/types/plots.py
+++ b/lightning/types/plots.py
@@ -114,7 +114,7 @@ class Adjacency(Base):
         """
 
         links = mat_to_links(matrix)
-        nodes = range(0, matrix.shape[0])
+        nodes = list(range(0, matrix.shape[0]))
         outdict = {'links': links, 'nodes': nodes}
 
         outdict = add_property(outdict, label, 'label')
@@ -254,7 +254,7 @@ class Force(Base):
         """
 
         links = mat_to_links(matrix)
-        nodes = range(0, matrix.shape[0])
+        nodes = list(range(0, matrix.shape[0]))
 
         outdict = {'links': links, 'nodes': nodes}
 


### PR DESCRIPTION
This is a fix for the problem addressed in this issue: https://github.com/lightning-viz/lightning-python/issues/16

This will enable Python 3 users to use Lightning without getting errors when plotting.
The errors were due to the difference between the ways Python 2 and Python 3 handle the `range` built-in. Python 2 `range` returns an actual container of values, whereas Python 3 `range` returns an iterator object. By casting `range` to `list`, it forces Python 3 to create a container for the values of the `range` iterator, while Python 2 will behavior remains the same.