### PR TITLE
Pym embedding

### DIFF
--- a/lightning/main.py
+++ b/lightning/main.py
@@ -49,10 +49,12 @@ class Lightning(object):
         self.ipython_enabled = True
         ip = get_ipython()
         formatter = ip.display_formatter.formatters['text/html']
-        formatter.for_type(Visualization, lambda viz, kwds=kwargs: viz.get_html())
+        formatter.for_type(Visualization, lambda viz, kwds=kwargs: viz.get_pym_html())
 
         r = requests.get(self.get_ipython_markup_link(), auth=self.auth)
+        display(Javascript(r.text))
 
+        r = requests.get("https://cdnjs.cloudflare.com/ajax/libs/pym/0.4.5/pym.js")
         display(Javascript(r.text))
 
     def disable_ipython(self):


### PR DESCRIPTION
This PR is an attempt to use pym to embed visualizations within notebooks instead of the current approach of getting html from the embed link. 

The advantages would be:
- An easy way to specify a global target size for visualizations, similar the different sizing "contexts" in `seaborn`. This fixes the current problem that many visualizations end up unreasonably wide, and unless they have a very horizontal aspect ratio, they fall off the page.
- Streaming updates happen immediately within notebooks!

![ipython](https://cloud.githubusercontent.com/assets/3387500/9049920/98c6b672-3a15-11e5-8ae2-e4d50d8b5638.gif)

And by using pym we still get dynamic height adjustment. Seems like an overall win, but there may be disadvantages I'm missing.

This implementation doesn't quite work yet, due to a `pym not defined` error in the browser that I'm trying to debug, but hopefully it's close. cc @mathisonian 