### PR TITLE
Size contexts

### DIFF
--- a/lightning/main.py
+++ b/lightning/main.py
@@ -5,7 +5,7 @@ from .visualization import Visualization
 
 class Lightning(object):
 
-    def __init__(self, host="http://localhost:3000", ipython=False, auth=None):
+    def __init__(self, host="http://localhost:3000", ipython=False, auth=None, size='medium'):
         self.set_host(host)
         self.auth = auth
 
@@ -23,6 +23,7 @@ class Lightning(object):
         else:
             self.ipython_enabled = False
 
+        self.set_size(size)
 
     def __repr__(self):
         if hasattr(self, 'session') and self.session is not None:
@@ -112,6 +113,17 @@ class Lightning(object):
 
         self.host = host
         return self
+
+    def set_size(self, size='medium'):
+        """
+        Set a figure size using one of four options.
+
+        Convention is 'small': 400px, 'medium': 600px, 'large': 800px,
+        and 'full' will use the entire width
+        """
+        if size not in ['small', 'medium', 'large', 'full']:
+            raise ValueError("Size must be one of 'small', 'medium', 'large', 'full'")
+        self.size = size
 
     def check_status(self):
         """

--- a/lightning/types/decorators.py
+++ b/lightning/types/decorators.py
@@ -10,6 +10,10 @@ def viztype(VizType):
     def plotter(self, *args, **kwargs):
         if not hasattr(self, 'session'):
             self.create_session()
+        if True and kwargs['height'] is None and kwargs['width'] is None:
+            if self.size != 'full':
+                kwargs['width'] = SIZES[self.size]
+
         viz = VizType.baseplot(self.session, VizType._name, *args, **kwargs)
         self.session.visualizations.append(viz)
         return viz
@@ -46,3 +50,9 @@ def viztype(VizType):
     setattr(Lightning, func, plotter)
 
     return VizType
+
+SIZES = {
+    'small': 400,
+    'medium': 600,
+    'large': 800,
+}

--- a/lightning/types/plots.py
+++ b/lightning/types/plots.py
@@ -155,16 +155,6 @@ class Adjacency(Base):
 class Line(Base):
 
     _name = 'line'
-    _options = dict(Base._options.items() + {
-        'log_scale_x': {
-            'default_value': False,
-            'lightning_name': 'logScaleX'
-        },
-        'log_scale_y': {
-            'default_value': False,
-            'lightning_name': 'logScaleY'
-        }
-    }.items())
 
     @staticmethod
     def clean(series, index=None, color=None, label=None, size=None, xaxis=None, yaxis=None):

--- a/lightning/visualization.py
+++ b/lightning/visualization.py
@@ -111,7 +111,7 @@ class Visualization(object):
         else:
             first_image, remaining_images = images[0], images[1:]
             files = {'file': first_image}
-            r = requests.post(url, files=files, data={'type': type, 'options': options}, auth=session.auth)
+            r = requests.post(url, files=files, data={'type': type, 'options': json.dumps(options)}, auth=session.auth)
             if r.status_code == 404:
                 raise Exception(r.text)
             elif not r.status_code == requests.codes.ok:


### PR DESCRIPTION
This PR uses the newly accessible `width` and `height` server-side options to support setting different "size contexts", which globally control the size of all generated figures. Fully manual control of all figure sizes is also available directly through the `width` and `height` keyword arguments.

![tmp](https://cloud.githubusercontent.com/assets/3387500/9156866/796b1dc2-3eb6-11e5-947f-498fcd5a5be4.png)

Similar to `seaborn`'s use of different size contexts ("notebook", "poster", etc.), thanks for the inspiration @mwaskom ! We decided on three sizes, "small" (`400px`), "medium" (`600px`), and "large" (`800px`), as well as "full", which horizontally fills the entire div.

Because we're just using Lightning's sizing machinery under the hood here, this should be trivial to port to the other clients.