### PR TITLE
don't allow NaN re #34

### DIFF
--- a/lightning/types/plots.py
+++ b/lightning/types/plots.py
@@ -651,4 +651,5 @@ class VegaLite(Base):
 
         outdict = {}
         outdict = add_property(outdict, spec, 'spec')
+
         return outdict

--- a/lightning/visualization.py
+++ b/lightning/visualization.py
@@ -107,7 +107,7 @@ class Visualization(object):
             if description:
                 payload['description'] = description
             headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
-            r = requests.post(url, data=json.dumps(payload), headers=headers, auth=session.auth)
+            r = requests.post(url, data=json.dumps(payload, allow_nan=False), headers=headers, auth=session.auth)
             if r.status_code == 404:
                 raise Exception(r.text)
             elif not r.status_code == requests.codes.ok:


### PR DESCRIPTION
This will provide an explicit error in the python side of things if there is a `NaN` issue instead of passing it on to the server which will error out with some hard to debug issues.